### PR TITLE
Add unhighlight, keep highlights between editors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,34 +3,31 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
-            "preLaunchTask": "npm: watch"
-        },
-        {
-            "name": "Extension Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}",
-                "--extensionTestsPath=${workspaceFolder}/out/test"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/out/test/**/*.js"
-            ],
-            "preLaunchTask": "npm: watch"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extensions"
+      ],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test"
+      ],
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
       {
         "command": "extension.highlight",
         "title": "Twitch Highlighter: Highlight Line"
+      },
+      {
+        "command": "extension.unhighlightAll",
+        "title": "Twitch Highlighter: Unhighlight All"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,60 +2,105 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
+import { Highlight } from "./highlight";
 
 const decorationType = vscode.window.createTextEditorDecorationType({
   backgroundColor: "green",
   border: "2px solid white"
 });
+let highlights: Array<Highlight> = new Array<Highlight>();
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  // Use the console to output diagnostic information (console.log) and errors (console.error)
-  // This line of code will only be executed once when your extension is activated
-  console.log(
-    'Congratulations, your extension "twitch-line-highlighter" is now active!'
+  // Listen for active text editor so we don't lose any existing highlights
+  let activeTextEditorListener = vscode.window.onDidChangeActiveTextEditor(
+    activeEditor => {
+      if (!activeEditor) {
+        return;
+      }
+
+      let existingHighlight = highlights.find(highlight => {
+        return (
+          highlight.editor.document.fileName === activeEditor.document.fileName
+        );
+      });
+      if (existingHighlight) {
+        activeEditor.setDecorations(
+          decorationType,
+          existingHighlight.decorations
+        );
+      }
+    }
   );
 
   // The command has been defined in the package.json file
   // Now provide the implementation of the command with  registerCommand
   // The commandId parameter must match the command field in package.json
-  let disposable = vscode.commands.registerCommand(
-    "extension.highlight",
+  let highlight = vscode.commands.registerCommand("extension.highlight", () => {
+    vscode.window
+      .showInputBox({ prompt: "Enter a line number" })
+      .then(handleHighlight);
+  });
+
+  let unhighlightAll = vscode.commands.registerCommand(
+    "extension.unhighlightAll",
     () => {
-      // The code you place here will be executed every time your command is executed
-      // note: doc.lineAt is zero based index so remember to always do -1 from input
-      // todo: toggle initiating separate background process that will listen and parse twitch chat
-      // todo: codephobia: make sure we create a away to unhighlight
-      // todo: teachtyle unhighlight based on timeout
-      // todo
-      vscode.window
-        .showInputBox({ prompt: "Enter a line number" })
-        .then(lineNumber => {
-          if (lineNumber) {
-            let editor = vscode.window.activeTextEditor;
-            if (editor) {
-              let doc = editor.document;
-              // prefix string with plus to make string a number
-              // well at least that's what codephobia says :P
-              const zeroIndexedLineNumber = +lineNumber - 1;
-              let textLine = doc.lineAt(zeroIndexedLineNumber);
-              let textLineLength = textLine.text.length;
-
-              let range = new vscode.Range(
-                new vscode.Position(zeroIndexedLineNumber, 0),
-                new vscode.Position(zeroIndexedLineNumber, textLineLength)
-              );
-
-              let decoration = { range };
-              editor.setDecorations(decorationType, [decoration]);
-            }
-          }
-        });
+      vscode.window.visibleTextEditors.forEach(visibleEditor => {
+        visibleEditor.setDecorations(decorationType, []);
+      });
+      highlights = new Array<Highlight>();
     }
   );
 
-  context.subscriptions.push(disposable);
+  function handleHighlight(lineNumber: string | undefined) {
+    if (!lineNumber || isNaN(+lineNumber)) {
+      return;
+    }
+
+    let editor = vscode.window.activeTextEditor;
+    if (editor) {
+      let doc = editor.document;
+      let existingHighlight = highlights.find(highlight => {
+        return highlight.editor.document.fileName === doc.fileName;
+      });
+      let range = getHighlightRange(lineNumber, doc);
+      let decoration = { range };
+      addHighlight(existingHighlight, decoration, editor);
+    }
+  }
+
+  context.subscriptions.push(highlight);
+  context.subscriptions.push(unhighlightAll);
+  context.subscriptions.push(activeTextEditorListener);
+}
+
+function addHighlight(
+  existingHighlight: Highlight | undefined,
+  decoration: { range: vscode.Range },
+  editor: vscode.TextEditor
+) {
+  if (existingHighlight) {
+    existingHighlight.decorations.push(decoration);
+    editor.setDecorations(decorationType, existingHighlight.decorations);
+  } else {
+    highlights.push(new Highlight([decoration], editor, "clarkio"));
+    editor.setDecorations(decorationType, [decoration]);
+  }
+}
+
+function getHighlightRange(lineNumber: string, doc: vscode.TextDocument) {
+  // prefix string with plus to make string a number
+  // well at least that's what codephobia says :P
+  const zeroIndexedLineNumber = +lineNumber - 1;
+  // note: doc.lineAt is zero based index so remember to always do -1 from input
+  let textLine = doc.lineAt(zeroIndexedLineNumber);
+  let textLineLength = textLine.text.length;
+  let range = new vscode.Range(
+    new vscode.Position(zeroIndexedLineNumber, 0),
+    new vscode.Position(zeroIndexedLineNumber, textLineLength)
+  );
+  return range;
 }
 
 // this method is called when your extension is deactivated

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -1,0 +1,9 @@
+import * as vscode from "vscode";
+
+export class Highlight {
+  constructor(
+    public decorations: Array<{ range: vscode.Range }>,
+    public editor: vscode.TextEditor,
+    public twichUser?: string
+  ) {}
+}


### PR DESCRIPTION
You know what I'm doing here so just merge 😉 

- Thanks to @parithon for finding and suggesting the `--disable-extensions` arg for our launch configuration. This saves a ton on memory when the extension host instance of VS Code is launched. P.S. you should probably audit your currently installed extensions since they may be causing a memory leak or eating all the CPU cycles
- Fixed implementation of adding highlight via class and array
- Implemented unhighlight all by using `setDecorators(decoratorType, [])` with an empty array (created [PR](https://github.com/Microsoft/vscode-extension-samples/pull/127) against vs code docs to clarify that use
- Added functionality to re-apply decorators when editor becomes active again. This was because we noticed that they were removed when we switched between files.